### PR TITLE
Fixed a lacking slash in friends grupo ini file.

### DIFF
--- a/METAbolt/GUI/Consoles/FriendsConsole.cs
+++ b/METAbolt/GUI/Consoles/FriendsConsole.cs
@@ -537,7 +537,8 @@ namespace METAbolt
             cbofgroups.Items.Add("...All friends");
             cbofgroups.SelectedIndex = 0;
 
-            string fconffile = METAbolt.DataFolder.GetDataFolder()  + client.Self.AgentID.ToString() + "_fr_groups.ini";
+            string fconffile = METAbolt.DataFolder.GetDataFolder() + "\\" + client.Self.AgentID.ToString() + "_fr_groups.ini";
+// maybe use "Path.Combine(METAbolt.DataFolder.GetDataFolder(),client.Self.AgentID.ToString() + "_fr_groups.ini");" ?
 
             if (!System.IO.File.Exists(fconffile))
             {


### PR DESCRIPTION
A lacking slash was causing the file [AgentID]_fr_groups.ini to be created in the root of data folder (C:\Users[user]\AppData\Roaming) instead in Metabolt subfolder and named as METAbolt[AgentID]_fr_groups.ini. Resulting path of the file was like "C:\Users[user]\AppData\Roaming\METAbolt[AgentID]_fr_groups.ini".
